### PR TITLE
fix: Enable auto-discovery for UNI-T UT363BT anemometer

### DIFF
--- a/custom_components/ble_monitor/const.py
+++ b/custom_components/ble_monitor/const.py
@@ -2242,6 +2242,7 @@ AUTO_MANUFACTURER_DICT = {
     'Tilt Blue'               : 'Tilt',
     'Tilt Yellow'             : 'Tilt',
     'Tilt Pink'               : 'Tilt',
+    'UT363BT'                 : 'UNI-T',
     'MJWSD06MMC'              : 'Xiaomi',
     'MMC-W505'                : 'Xiaomi',
     'SJWS01LM'                : 'Xiaomi',


### PR DESCRIPTION
This commit enables auto-discovery for the UNI-T UT363BT anemometer.

The UT363BT model identifier has been added to `AUTO_MANUFACTURER_DICT` in `custom_components/ble_monitor/const.py`. This allows the integration to automatically discover and add the UNI-T anemometer when it's detected, provided that discovery is generally enabled in the component's settings.

This addresses your feedback that the device was not being auto-discovered after the initial integration merge.