### PR TITLE
Fix UT363BT discovery

### DIFF
--- a/custom_components/ble_monitor/ble_parser/uni_t.py
+++ b/custom_components/ble_monitor/ble_parser/uni_t.py
@@ -27,10 +27,11 @@ def parse_uni_t(self, mfg: bytes, mac: bytes) -> dict | None:
         _LOGGER.debug("UNI‑T decode failed: %s", err)
         return None
 
+    device_type = "UT363BT"
     return {
         "mac":         to_unformatted_mac(mac),
-        "type":        "UNI‑T",
-        "firmware":    "UT363BT",
+        "type":        device_type,
+        "firmware":    device_type,
         "packet":      pkt,
         "wind_speed":  round(speed, 2),
         "temperature": temp,


### PR DESCRIPTION
## Summary
- fix UT363BT parser return type

## Testing
- `pytest custom_components/ble_monitor/test/test_uni_t_parser.py::TestUniTParser::test_uni_t_ut363bt_valid_data -q` *(fails: ImportError: cannot import name 'UnitOfConductivity' from 'homeassistant.const')*

------
https://chatgpt.com/codex/tasks/task_e_683f47fae3d0832ba7dd1cd54cdfb7d4